### PR TITLE
.lnk files, hosts files, and .exe.bat keycuts

### DIFF
--- a/keycuts.Common/Shortcut.cs
+++ b/keycuts.Common/Shortcut.cs
@@ -99,6 +99,7 @@ namespace keycuts.Common
                     }
                     else
                     {
+                        IsLink(destination, out newDestination);
                         type = ShortcutType.File;
                     }
                 }

--- a/keycuts.Common/Shortcut.cs
+++ b/keycuts.Common/Shortcut.cs
@@ -42,7 +42,9 @@ namespace keycuts.Common
             Type = GetShortcutType(destination, out string newDestination);
             Destination = newDestination;
             Extension = ".bat";
-            Filename = Path.GetFileNameWithoutExtension(shortcut);
+            Filename = shortcut.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase) ? 
+                shortcut :
+                Path.GetFileNameWithoutExtension(shortcut);
             FilenameWithExtension = $"{Filename}{Extension}";
             Folder = IsNotFullPath(shortcut) ?
                 defaultFolder :


### PR DESCRIPTION
* BAT - hosts file shows OpenWithApp
* Common - Resolves .lnk (Windows shortcut) files before creating keycuts
* Common - Allows shortcutname**.exe** keycuts now (shortcutname.exe.bat) -- useful for putting any executable in the path from its current location!